### PR TITLE
Refactor and fix issue of handling colon in command subject.

### DIFF
--- a/module/move/wca/tests/inc/commands_aggregator/basic.rs
+++ b/module/move/wca/tests/inc/commands_aggregator/basic.rs
@@ -344,8 +344,7 @@ tests_impls!
     a_id!( grammar_command.subjects, vec![ TheModule::Value::String( "qwe:rty".into() ) ] );
   }
 
-  // qqq: subject should be parsed if optional property is not specified
-  fn optional_prop_subject_with_colon() 
+  fn optional_prop_subject_with_colon()
   {
     let grammar = GrammarConverter::former()
     .command

--- a/module/move/wca/tests/inc/grammar/from_command.rs
+++ b/module/move/wca/tests/inc/grammar/from_command.rs
@@ -62,22 +62,23 @@ tests_impls!
     a_id!( vec![ Value::String( "subject".to_string() ) ], grammar_command.subjects );
     a_true!( grammar_command.properties.is_empty() );
 
-    // with more subjects that it is setted
+    // with more subjects that it is set
     let raw_command = parser.command( ".command subject1 subject2" ).unwrap();
 
     let grammar_command = grammar_converter.to_command( raw_command );
     a_true!( grammar_command.is_err() );
 
-    // with subject and property that isn't declareted
+    // with subject and property that isn't declared
     let raw_command = parser.command( ".command subject prop:value" ).unwrap();
 
     a_true!( grammar_converter.to_command( raw_command ).is_err() );
 
-    // with property that isn't declareted and without subject
+    // subject with colon when property not declared
     let raw_command = parser.command( ".command prop:value" ).unwrap();
 
-    let grammar_command = grammar_converter.to_command( raw_command );
-    a_true!( grammar_command.is_err() );
+    let grammar_command = grammar_converter.to_command( raw_command ).unwrap();
+    a_id!( vec![ Value::String( "prop:value".to_string() ) ], grammar_command.subjects );
+    a_true!( grammar_command.properties.is_empty() );
   }
 
   fn subject_type_check()


### PR DESCRIPTION
The `to_command` function has been significantly refactored for better readability, maintainability, and error handling. The refactor includes breaking down the giant function into several smaller, more manageable helper functions. Most importantly, the issue of handling a colon ':' in the command subject, has been fixed to appropriately parse commands when the property is not declared. This ensures that the command subjects are correctly identified and extracted.